### PR TITLE
docs: import the balance example symbols from the package root

### DIFF
--- a/docs/utilities/data.md
+++ b/docs/utilities/data.md
@@ -224,7 +224,7 @@ When working with large datasets, it's important to process data efficiently to 
 
 ```typescript
 import { paginateItems } from 'midaz-sdk/util/data/pagination';
-import { formatAccountBalance } from 'midaz-sdk/util/data/formatting';
+import { formatAccountBalance, formatBalance, Account } from '@lerianstudio/midaz-sdk';
 
 async function analyzeAccountBalances(client, orgId, ledgerId) {
   // Set up counters


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Pipeline
- [ ] Tests
- [x] Documentation

## What this does

Closes the one CodeRabbit thread left open on #176 (`docs/utilities/data.md`). The balance example calls `formatBalance` and types a paginator as `Account` while importing neither, so copying it does not compile.

The first attempt at this added the imports in the file's existing style — `from 'midaz-sdk/util/data/formatting'` — which does not resolve either. Measured:

```
require('@lerianstudio/midaz-sdk/util/data/formatting')  -> MODULE_NOT_FOUND
require('midaz-sdk/util/data/formatting')                -> MODULE_NOT_FOUND
package.json exports: {".": {...}}     // no subpaths, and the package is scoped
```

All three symbols are root exports, so the example now imports from `@lerianstudio/midaz-sdk`.

## Verification

Type-checked in isolation against the built declarations, and proven non-vacuous — renaming one symbol turns it red:

```
tsc -p .        -> exit 0
# after breaking the name:
v.ts(1,32): error TS2724: '"@lerianstudio/midaz-sdk"' has no exported member named 'formatBalanceZZZ'.
```

## Additional Notes

**This is one example in a repo-wide problem, and the rest is deliberately out of scope.** 63 documentation files import from `midaz-sdk` — the wrong package name — and most reach for subpaths the `exports` map does not expose: 83 bare `from 'midaz-sdk'`, plus `util/error` (32), `util` (32), `util/validation` (28), `util/concurrency` (20) and others. None of them resolve. This was first flagged during #174 and left for a dedicated docs pass; it still deserves one. Fixing only the example this thread names keeps the change reviewable, but a reader copying almost any other snippet in `docs/` will hit the same wall.

## Obs: Please, always remember to target your PR to develop branch instead of main.