### PR TITLE
fix(ci): use shared gptchangelog workflow for changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,23 +101,6 @@ jobs:
 
   generate-changelog:
     name: 📝 Generate AI-powered Changelog
-    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: publish_release
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-
-      - uses: LerianStudio/github-actions-gptchangelog@main
-        with:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LERIAN_CI_CD_USER_GPG_KEY: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-          LERIAN_CI_CD_USER_GPG_KEY_PASSWORD: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-          LERIAN_CI_CD_USER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          LERIAN_CI_CD_USER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.56.0
+    secrets: inherit


### PR DESCRIPTION
Replaces the direct call to the deprecated `LerianStudio/github-actions-gptchangelog` action with the reusable `gptchangelog.yml` workflow from `github-actions-shared-workflows` (pinned `@v1.56.0`). Part of the org-wide consolidation of standalone `github-actions-*` repos into `github-actions-shared-workflows`; once all consumers are migrated, `github-actions-gptchangelog` will be archived.

Secrets pass via `secrets: inherit`. The shared workflow expects `OPENROUTER_API_KEY` (previously `OPENAI_API_KEY`) — confirm this org-level secret is available.

## Testing
Verify on the next merge to develop/main that the `generate-changelog` job runs and completes successfully.